### PR TITLE
Gbl.master

### DIFF
--- a/pyntlm.py
+++ b/pyntlm.py
@@ -339,7 +339,7 @@ def handle_type3(req, ntlm_message):
             domain,user,req.unparsed_uri))
         return handle_unauthorized(req)
 
-    req.log_error('PYNTLM: User %s/%s has been authenticated to access URI %s' % (user,domain,req.unparsed_uri), apache.APLOG_NOTICE)
+    req.log_error('PYNTLM: User %s/%s has been authenticated to access URI %s' % (user,domain,req.unparsed_uri), apache.APLOG_INFO)
     set_remote_user(req, user, domain)
     result = check_authorization(req, user, proxy)
     cache.remove(req.connection.id)
@@ -373,7 +373,7 @@ def handle_basic(req, user, password):
             user,domain,req.unparsed_uri))
         return handle_unauthorized(req)
     
-    req.log_error('PYNTLM: User %s/%s has been authenticated (Basic) to access URI %s' % (user,domain,req.unparsed_uri), apache.APLOG_NOTICE)
+    req.log_error('PYNTLM: User %s/%s has been authenticated (Basic) to access URI %s' % (user,domain,req.unparsed_uri), apache.APLOG_INFO)
     set_remote_user(req, user, domain)
     result = check_authorization(req, user, proxy)
     proxy.close()

--- a/pyntlm.py
+++ b/pyntlm.py
@@ -167,6 +167,12 @@ def set_remote_user(req, username, domain):
         req.user = domain + '\\' + username
     else:
         req.user = username
+    namecase = req.get_options().get('NameCase', 'ignore').lower()
+    if namecase == 'lower':
+        req.user = req.user.lower()
+    elif namecase == 'upper':
+        req.user = req.user.upper()
+    
 
 def decode_http_authorization_header(auth):
     '''Return a tuple with the parsed content of an HTTP Authorization header


### PR DESCRIPTION
NTLM on Firefox will convert all usernames to uppercase. This might cause confusion when you're upgrading from basic Auth to NTLM and have lowercase usernames in your database. This adds an option NameCase which you can set to 'lower' or 'upper', which enforces lowercase/uppercase in REMOTE_USER. Omitting this option makes PyAuthenNTLM2 behave like it does now.

Also, at least some versions of Apache will always log AP_NOTICE, independent of Log Level, which causes a lot of spam in error_log. This version fixes that by using AP_INFO instead of AP_NOTICE.
